### PR TITLE
fix(routes): protect asterium list and detail endpoints with auth

### DIFF
--- a/src/controllers/asterium.controller.ts
+++ b/src/controllers/asterium.controller.ts
@@ -9,6 +9,17 @@ export async function listPublished(_req: any, res: any) {
   res.json(rows);
 }
 
+export async function getDiscovery(req:any, res:any){
+  const {id} = req.params;
+  const row = await Asterium.findByPk(Number(id),{
+    include: [{association: "author", attributes:["id", "username", "email"]}]
+  });
+  if (!row) {
+    return res.status(404).json({error:"Descubrimiento no encontrado"});
+  }
+  res.json(row);
+}
+
 export async function createDiscovery(req: any, res: any) {
   const body = req.body;
   const row = await Asterium.create({

--- a/src/routes/asterium.routes.ts
+++ b/src/routes/asterium.routes.ts
@@ -6,8 +6,11 @@ import {createDiscoverySchema, updateDiscoverySchema, idParamSchema,} from "../s
 
 const asteriumRouter = express.Router();
 
-// Listado público de descubrimientos publicados
-asteriumRouter.get("/", asteriumController.listPublished);
+// Listado de descubrimientos publicados (solo usuarios logueados)
+asteriumRouter.get("/", requireAuth, asteriumController.listPublished);
+
+//Obtener un descubrimiento ESPECÍFICO por ID (solo usuarios logueados)
+asteriumRouter.get("/:id", requireAuth, validate(idParamSchema, "params"), asteriumController.getDiscovery);
 
 // Crear un descubrimiento (por defecto: solo admin, aunque podrías cambiar a permitir "user")
 asteriumRouter.post("/", requireAuth, validate(createDiscoverySchema), asteriumController.createDiscovery);


### PR DESCRIPTION
- Added requireAuth to GET /asterium and GET /asterium/:id
- Now only logged-in users can view list and detail of discoveries
- Matches project requirement: viewing requires authentication